### PR TITLE
[WIP] aarch64-darwin support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -114,14 +114,17 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "path": "/nix/store/qcvnd2dsa5a3h4gq8x5x7hds6z85i4dw-source",
-        "type": "path"
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "gitsigns-nvim": {
@@ -311,11 +314,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660227034,
-        "narHash": "sha256-bXMlG/YU0IjAod6M625XT1YbUG+/3L9ypk9llYpKeuM=",
+        "lastModified": 1660639432,
+        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "964d60ff2e6bc76c0618962da52859603784fa78",
+        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
         "type": "github"
       },
       "original": {

--- a/lib/buildPlugin.nix
+++ b/lib/buildPlugin.nix
@@ -21,7 +21,7 @@
     p.tree-sitter-css
     p.tree-sitter-graphql
     p.tree-sitter-json
-    pkgs.tree-sitter-hare
+    # pkgs.tree-sitter-hare
   ]);
 
   buildPlug = name:
@@ -35,7 +35,7 @@
           rm -r parser
           ln -s ${treesitterGrammars} parser
           mkdir queries/hare
-          ln -s ${pkgs.tree-sitter-hare}/queries/* queries/hare
+          echo ln -s ${"pkgs.tree-sitter-hare"}/queries/* queries/hare
         ''
         else "";
     };


### PR DESCRIPTION
This is preliminary `aarch64-darwin` support. I just did some hacks in order to have it running for scala. 

* Added an overlay to use intel-darwin `llvm < 11` packages which are disabled on M1 but are usable via rosetta2.
* Disabled `tree-sitter-hare` from @jdpkgs since it looks it's linux only. Would need later other arch support in that flake.
* Disabled dhall, elm and haskell since I needed this to at least work for Scala to make a coworker happy.


Hope it might be useful for other people running on M1, and if there's enough interest we can later improve this PR to not be so hackish and eventually merged.

M1 version runnable with `nix run 'github:vic/neovim-flake/m1#nvim'`

thanks for sharing this flake.