### PR TITLE
fix which-key plugin warnings

### DIFF
--- a/modules/comments/default.nix
+++ b/modules/comments/default.nix
@@ -35,10 +35,8 @@ in
       }
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>c"] = {
-            name = "Commenter",
-          },
+        wk.add({
+          { "<leader>c", group = "Commenter" },
         })
       ''}
     '';

--- a/modules/filetree/nvimtreelua.nix
+++ b/modules/filetree/nvimtreelua.nix
@@ -186,10 +186,8 @@ in
       ''}
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>t"] = {
-            name = "Tree & Todo",
-          },
+        wk.add({
+          { "<leader>t", group = "Tree & Todo" },
         })
       ''}
     '';

--- a/modules/git/git.nix
+++ b/modules/git/git.nix
@@ -67,7 +67,7 @@ in
 
             -- Actions
             ${writeIf keys.enable ''
-            wk.register({
+            wk.add({
               ["<leader>g"] = {
                 name = "Gitsigns",
                 b = { function() gs.blame_line{full=true} end, "Blame (full)" },
@@ -103,8 +103,8 @@ in
         require('neogit').setup {}
 
           ${writeIf keys.enable ''
-          wk.register({
-            ["<leader>gn"] = { "<cmd> Neogit kind=auto<CR>", "Open neogit" },
+          wk.add({
+            { "<leader>gn", "<cmd> Neogit kind=auto<CR>", desc = "Open neogit" },
           })
           ''}
 

--- a/modules/harpoon/default.nix
+++ b/modules/harpoon/default.nix
@@ -45,12 +45,10 @@ in
       ''}
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>h"] = {
-            name = "Harpoon",
-            a = { "<cmd>lua require('harpoon'):list():add()<CR>", "Add" },
-            d = { "<cmd>lua require('harpoon'):list():remove()<CR>", "Del" },
-          },
+        wk.add({
+          { "<leader>h", group = "Harpoon" },
+          { "<leader>ha", "<cmd>lua require('harpoon'):list():add()<CR>", desc = "Add" },
+          { "<leader>hd", "<cmd>lua require('harpoon'):list():remove()<CR>", desc = "Del" },
         })
       ''}
     '';

--- a/modules/lsp/lsp.nix
+++ b/modules/lsp/lsp.nix
@@ -267,19 +267,15 @@ in
       };
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>l"] = {
-            name = "LSP",
-          },
+        wk.add({
+          { "<leader>l", group = "LSP" },
         })
 
         ${writeIf cfg.scala.enable ''
-        wk.register({
-          ["<leader>m"] = {
-            name = "Metals",
-            w = { "<cmd>lua require'metals'.worksheet_hover()<CR>", "Worksheet hover" },
-            d = { "<cmd>lua require'metals'.open_all_diagnostics()<CR>", "Open all diagnostics" },
-          },
+        wk.add({
+          { "<leader>m", group = "Metals" },
+          { "<leader>w", "<cmd>lua require'metals'.worksheet_hover()<CR>", desc = "Worksheet hover" },
+          { "<leader>d", "<cmd>lua require'metals'.open_all_diagnostics()<CR>", desc = "Open all diagnostics" },
         })
         ''}
       ''}

--- a/modules/lsp/nvim-code-action-menu.nix
+++ b/modules/lsp/nvim-code-action-menu.nix
@@ -21,10 +21,8 @@ in
 
     vim.luaConfigRC = ''
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>a"] = {
-            name = "Code actions",
-          },
+        wk.add({
+          { "<leader>a", group = "Code actions" },
         })
       ''}
     '';

--- a/modules/lsp/trouble.nix
+++ b/modules/lsp/trouble.nix
@@ -27,10 +27,8 @@ in
       require("trouble").setup {}
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>x"] = {
-            name = "Troubles",
-          },
+        wk.add({
+          { "<leader>x", group = "Troubles" },
         })
       ''}
     '';

--- a/modules/tabline/nvim-bufferline.nix
+++ b/modules/tabline/nvim-bufferline.nix
@@ -78,7 +78,6 @@ in
               offsets = {{filetype = "NvimTree", text = "File Explorer", text_align = "left"}},
               sort_by = 'extension',
               diagnostics = "nvim_lsp",
-              diagnostics_update_in_insert = true,
               diagnostics_indicator = function(count, level, diagnostics_dict, context)
                  local s = ""
                  for e, n in pairs(diagnostics_dict) do
@@ -96,11 +95,11 @@ in
            }
         }
 
+        vim.diagnostic.config { update_in_insert = true }
+
         ${writeIf keys.enable ''
-          wk.register({
-            ["<leader>b"] = {
-              name = "Buffers",
-            },
+          wk.add({
+            {"<leader>b", group = "Buffers" },
           })
         ''}
       '';

--- a/modules/telescope/default.nix
+++ b/modules/telescope/default.nix
@@ -84,10 +84,8 @@ in
       ''}
 
       ${writeIf keys.enable ''
-        wk.register({
-          ["<leader>f"] = {
-            name = "Telescope",
-          },
+        wk.add({
+          { "<leader>f", group = "Telescope" },
         })
       ''}
 

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -157,11 +157,9 @@ in
 
         ${writeIf cfg.noice.enable ''
             ${writeIf keys.enable ''
-              wk.register({
-                ["<leader>n"] = {
-                  name = "Noice",
-                  d = { "<cmd> NoiceDismiss <CR>", "Dismiss notifications" },
-                },
+              wk.add({
+                { "<leader>n", group = "Noice" },
+                { "<leader>nd", "<cmd> NoiceDismiss <CR>", desc = "Dismiss notifications" }
               })
             ''}
 


### PR DESCRIPTION
Following the suggestions from `:checkhealth which-key` results in this runtime error on startup:

```console
Error executing vim.schedule lua callback: vim/keymap.lua:0: Invalid (empty) LHS
stack traceback:                                                                                               
        [C]: in function 'nvim_set_keymap'                                                                     
        vim/keymap.lua: in function 'set'                                                                      
        ...ges/start/vimplugin-which-key/lua/which-key/mappings.lua:302: in function 'create'                  
        ...ges/start/vimplugin-which-key/lua/which-key/mappings.lua:314: in function 'parse'                   
        ...kages/start/vimplugin-which-key/lua/which-key/config.lua:327: in function 'add'                     
        ...kages/start/vimplugin-which-key/lua/which-key/config.lua:285: in function ''                        
        vim/_editor.lua: in function <vim/_editor.lua:0>      
```

See https://github.com/folke/which-key.nvim/issues/927